### PR TITLE
Catch SIGTERM on default settings.

### DIFF
--- a/sigmod/defaults.go
+++ b/sigmod/defaults.go
@@ -2,6 +2,12 @@
 
 package sigmod
 
-import "os"
+import (
+	"os"
+	"syscall"
+)
 
-var defaultSignals = []os.Signal{os.Interrupt}
+var defaultSignals = []os.Signal{
+	os.Interrupt,
+	syscall.SIGTERM,
+}

--- a/sigmod/signal_unix_test.go
+++ b/sigmod/signal_unix_test.go
@@ -12,8 +12,10 @@ import (
 )
 
 func TestListenerDefaultSignal(t *testing.T) {
-	// Decoupled from sigmod.defaultSignals to detect breaking changes.
-	testSignals := []syscall.Signal{syscall.SIGINT}
+	testSignals := []syscall.Signal{
+		syscall.SIGINT,
+		syscall.SIGTERM,
+	}
 
 	for _, sig := range testSignals {
 		t.Run(sig.String(), func(t *testing.T) {


### PR DESCRIPTION
This is useful with services like AWS Fargate where SIGTERM is sent when container is being stopped [1]. Can drastically speed up the shutdown and most importantly does it gracefully.

Caveats: won't work on Windows.

[1] https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/