### PR TITLE
Fix tracemod dependabot directory typo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,7 +57,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "gomod"
-    directory: "/tracermod"
+    directory: "/tracemod"
     schedule:
       interval: "daily"
     groups:


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml` referenced `/tracermod`, but the directory is `/tracemod` — `tracemod` was silently excluded from dependabot updates.

## Test plan
- [ ] CI passes
- [ ] Confirm dependabot picks up `tracemod` on the next scheduled run