### PR TITLE
Polish docs and fix broken README examples

### DIFF
--- a/httpmod/README.md
+++ b/httpmod/README.md
@@ -2,6 +2,8 @@
 
 # httpmod
 
+httpmod runs an `http.Server` as a srvc module and shuts it down gracefully on exit.
+
 ```go
 package main
 

--- a/logmod/README.md
+++ b/logmod/README.md
@@ -21,9 +21,10 @@ func main() {
 		logmod.New(),
 		tickermod.New(
 			tickermod.WithInterval(5*time.Second),
-			tickermod.WithFunc(func() {
-				// Slog uses now otelslog bridge configured by logmod.
+			tickermod.WithFunc(func() error {
+				// slog routes through the otelslog bridge configured by logmod.
 				slog.Info("Hello, World!")
+				return nil
 			}),
 		),
 	)

--- a/logmod/provider.go
+++ b/logmod/provider.go
@@ -1,4 +1,4 @@
-// Package logmod provides OpenTelemetry trace provider as a module.
+// Package logmod provides OpenTelemetry log provider as a module.
 package logmod
 
 import (

--- a/sigmod/README.md
+++ b/sigmod/README.md
@@ -2,6 +2,8 @@
 
 # sigmod
 
+sigmod listens for OS signals and returns from Run when one is received, triggering srvc shutdown.
+
 ```go
 package main
 

--- a/sqlmod/db.go
+++ b/sqlmod/db.go
@@ -58,12 +58,12 @@ func (d *DB) Stop() error {
 
 func (d *DB) ID() string { return ID }
 
-// DB returns *sql.DB instance.
-// This should be only call after Init.
+// DB returns the underlying *sql.DB. Only valid after Init has run.
 func (d *DB) DB() *sql.DB { return d.db }
 
 type Opt func(*DB) error
 
+// WithDSN opens a *sql.DB from the given driver name and DSN.
 func WithDSN(driver, dsn string) Opt {
 	return func(d *DB) error {
 		db, err := sql.Open(driver, dsn)

--- a/sqlxmod/db.go
+++ b/sqlxmod/db.go
@@ -60,12 +60,12 @@ func (d *DB) Stop() error {
 
 func (d *DB) ID() string { return ID }
 
-// DB returns *sqlx.DB instance.
-// This should be only call after Init.
+// DB returns the underlying *sqlx.DB. Only valid after Init has run.
 func (d *DB) DB() *sqlx.DB { return d.dbx }
 
 type Opt func(*DB) error
 
+// WithDSN opens a *sqlx.DB from the given driver name and DSN.
 func WithDSN(driver, dsn string) Opt {
 	return func(d *DB) error {
 		dbx, err := sqlx.Open(driver, dsn)

--- a/tickermod/README.md
+++ b/tickermod/README.md
@@ -2,6 +2,8 @@
 
 # tickermod
 
+tickermod runs a function on a fixed interval. The ticker stops when the function returns a non-nil error.
+
 ```go
 package main
 
@@ -17,8 +19,9 @@ func main() {
 	srvc.RunAndExit(
 		tickermod.New(
 			tickermod.WithInterval(5*time.Second),
-			tickermod.WithFunc(func() {
+			tickermod.WithFunc(func() error {
 				slog.Info("Hello, World!")
+				return nil
 			}),
 		),
 	)


### PR DESCRIPTION
## Summary
Audit pass across all module docs and READMEs.

**Bugs:**
- `logmod` package doc said "OpenTelemetry trace provider as a module" (copy-paste from tracemod). Fixed to "log provider".
- `tickermod` README example used `WithFunc(func() {})` but `WithFunc` takes `func() error`. The README example would not compile.
- `logmod` README example had the same broken `WithFunc` signature. Fixed and reworded a small typo on the inline comment.

**Missing docs:**
- `sqlmod.WithDSN` and `sqlxmod.WithDSN` had no doc comment. Added one-line each.
- `sqlmod.DB().DB` and `sqlxmod.DB().DB` doc had broken grammar ("This should be only call after Init."). Rewritten.

**Consistency:**
- `httpmod`, `sigmod`, `tickermod` READMEs had no one-line description above the code block, unlike the others. Added one each.

No code changes, no behavior change.

## Test plan
- [ ] go test -race for logmod, sqlmod, sqlxmod, tickermod passes (local)
- [ ] CI green