### PR TITLE
Give each mod README a full-service usage example

### DIFF
--- a/httpmod/README.md
+++ b/httpmod/README.md
@@ -8,37 +8,26 @@ httpmod runs an `http.Server` as a srvc module and shuts it down gracefully on e
 package main
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
 
 	"github.com/go-srvc/mods/httpmod"
+	"github.com/go-srvc/mods/sigmod"
 	"github.com/go-srvc/srvc"
 )
 
 func main() {
 	srvc.RunAndExit(
+		sigmod.New(os.Interrupt),
 		httpmod.New(
-			httpmod.WithServerFn(CreateServer),
+			httpmod.WithAddr(":8080"),
+			httpmod.WithHandler(http.HandlerFunc(hello)),
 		),
 	)
 }
 
-func CreateServer() (*http.Server, error) {
-	addr := os.Getenv("ADDR")
-	if addr == "" {
-		return nil, errors.New("ADDR is required")
-	}
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "World!")
-	})
-
-	return &http.Server{
-		Addr:    addr,
-		Handler: mux,
-	}, nil
+func hello(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "hello, world")
 }
 ```

--- a/logmod/README.md
+++ b/logmod/README.md
@@ -2,31 +2,36 @@
 
 # logmod
 
-Using logmod takes care of exporting logs to otel endpoint and flushing log buffers before the application exits.
+logmod exports logs to the otel endpoint and flushes log buffers before the application exits. After `logmod.New()` runs, `slog` calls are routed through the otelslog bridge.
 
 ```go
 package main
 
 import (
+	"fmt"
 	"log/slog"
-	"time"
+	"net/http"
+	"os"
 
+	"github.com/go-srvc/mods/httpmod"
 	"github.com/go-srvc/mods/logmod"
-	"github.com/go-srvc/mods/tickermod"
+	"github.com/go-srvc/mods/sigmod"
 	"github.com/go-srvc/srvc"
 )
 
 func main() {
 	srvc.RunAndExit(
 		logmod.New(),
-		tickermod.New(
-			tickermod.WithInterval(5*time.Second),
-			tickermod.WithFunc(func() error {
-				// slog routes through the otelslog bridge configured by logmod.
-				slog.Info("Hello, World!")
-				return nil
-			}),
+		sigmod.New(os.Interrupt),
+		httpmod.New(
+			httpmod.WithAddr(":8080"),
+			httpmod.WithHandler(http.HandlerFunc(hello)),
 		),
 	)
+}
+
+func hello(w http.ResponseWriter, r *http.Request) {
+	slog.InfoContext(r.Context(), "request", "path", r.URL.Path)
+	fmt.Fprint(w, "ok")
 }
 ```

--- a/metermod/README.md
+++ b/metermod/README.md
@@ -2,21 +2,34 @@
 
 # metermod
 
-Using metermod takes care of exporting metrics to otel endpoint and flushing buffers before the application exits.
+metermod exports metrics to the otel endpoint and flushes buffers before the application exits. By default it also collects Go runtime metrics.
 
 ```go
 package main
 
 import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/go-srvc/mods/httpmod"
 	"github.com/go-srvc/mods/metermod"
+	"github.com/go-srvc/mods/sigmod"
 	"github.com/go-srvc/srvc"
 )
 
 func main() {
 	srvc.RunAndExit(
-		// By default metermod exports go runtime metrics to otel endpoint.
 		metermod.New(),
+		sigmod.New(os.Interrupt),
+		httpmod.New(
+			httpmod.WithAddr(":8080"),
+			httpmod.WithHandler(http.HandlerFunc(hello)),
+		),
 	)
 }
 
+func hello(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "ok")
+}
 ```

--- a/sigmod/README.md
+++ b/sigmod/README.md
@@ -8,8 +8,10 @@ sigmod listens for OS signals and returns from Run when one is received, trigger
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"os"
+	"syscall"
 
 	"github.com/go-srvc/mods/httpmod"
 	"github.com/go-srvc/mods/sigmod"
@@ -18,13 +20,16 @@ import (
 
 func main() {
 	srvc.RunAndExit(
-		// Register the signal module to handle SIGINT
-		// and trigger graceful shutdown of all modules.
-		sigmod.New(os.Interrupt),
+		// Trigger graceful shutdown of all modules on SIGINT or SIGTERM.
+		sigmod.New(os.Interrupt, syscall.SIGTERM),
 		httpmod.New(
 			httpmod.WithAddr(":8080"),
-			httpmod.WithHandler(http.DefaultServeMux),
+			httpmod.WithHandler(http.HandlerFunc(hello)),
 		),
 	)
+}
+
+func hello(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "hello, world")
 }
 ```

--- a/sqlmod/README.md
+++ b/sqlmod/README.md
@@ -2,16 +2,19 @@
 
 # sqlmod
 
-sqlmod takes care of gracefully closing connection pool when application exits.
+sqlmod wraps `database/sql` as a module and closes the connection pool gracefully when the application exits.
 
 ```go
 package main
 
 import (
-	"context"
+	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/XSAM/otelsql"
+	"github.com/go-srvc/mods/httpmod"
+	"github.com/go-srvc/mods/sigmod"
 	"github.com/go-srvc/mods/sqlmod"
 	"github.com/go-srvc/srvc"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
@@ -20,26 +23,29 @@ import (
 )
 
 func main() {
-	srvc.RunAndExit(
-		New(),
-	)
-}
-
-// Store embeds the sqlmod.DB
-type Store struct {
-	*sqlmod.DB
-}
-
-func New() *Store {
 	db := sqlmod.New(
 		sqlmod.WithOtel("pgx", os.Getenv("DSN"),
 			otelsql.WithAttributes(semconv.DBSystemNamePostgreSQL),
 		),
 	)
-	return &Store{DB: db}
+	srvc.RunAndExit(
+		sigmod.New(os.Interrupt),
+		db,
+		httpmod.New(
+			httpmod.WithAddr(":8080"),
+			httpmod.WithHandler(handler(db)),
+		),
+	)
 }
 
-func (s *Store) Healthy(ctx context.Context) error {
-	return s.DB.DB().PingContext(ctx)
+func handler(db *sqlmod.DB) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var version string
+		if err := db.DB().QueryRowContext(r.Context(), "SELECT version()").Scan(&version); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprintf(w, "db version: %s\n", version)
+	})
 }
 ```

--- a/sqlxmod/README.md
+++ b/sqlxmod/README.md
@@ -2,16 +2,19 @@
 
 # sqlxmod
 
-sqlxmod wraps [jmoiron/sqlx](https://github.com/jmoiron/sqlx) and takes care of gracefully closing connection pool when application exits.
+sqlxmod wraps [jmoiron/sqlx](https://github.com/jmoiron/sqlx) as a module and closes the connection pool gracefully when the application exits.
 
 ```go
 package main
 
 import (
-	"context"
+	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/XSAM/otelsql"
+	"github.com/go-srvc/mods/httpmod"
+	"github.com/go-srvc/mods/sigmod"
 	"github.com/go-srvc/mods/sqlxmod"
 	"github.com/go-srvc/srvc"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
@@ -20,26 +23,29 @@ import (
 )
 
 func main() {
-	srvc.RunAndExit(
-		New(),
-	)
-}
-
-// Store embeds the sqlxmod.DB
-type Store struct {
-	*sqlxmod.DB
-}
-
-func New() *Store {
 	db := sqlxmod.New(
 		sqlxmod.WithOtel("pgx", os.Getenv("DSN"),
 			otelsql.WithAttributes(semconv.DBSystemNamePostgreSQL),
 		),
 	)
-	return &Store{DB: db}
+	srvc.RunAndExit(
+		sigmod.New(os.Interrupt),
+		db,
+		httpmod.New(
+			httpmod.WithAddr(":8080"),
+			httpmod.WithHandler(handler(db)),
+		),
+	)
 }
 
-func (s *Store) Healthy(ctx context.Context) error {
-	return s.DB.DB().PingContext(ctx)
+func handler(db *sqlxmod.DB) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var version string
+		if err := db.DB().GetContext(r.Context(), &version, "SELECT version()"); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprintf(w, "db version: %s\n", version)
+	})
 }
 ```

--- a/tickermod/README.md
+++ b/tickermod/README.md
@@ -9,18 +9,23 @@ package main
 
 import (
 	"log/slog"
+	"os"
 	"time"
 
+	"github.com/go-srvc/mods/logmod"
+	"github.com/go-srvc/mods/sigmod"
 	"github.com/go-srvc/mods/tickermod"
 	"github.com/go-srvc/srvc"
 )
 
 func main() {
 	srvc.RunAndExit(
+		logmod.New(),
+		sigmod.New(os.Interrupt),
 		tickermod.New(
 			tickermod.WithInterval(5*time.Second),
 			tickermod.WithFunc(func() error {
-				slog.Info("Hello, World!")
+				slog.Info("tick")
 				return nil
 			}),
 		),

--- a/tracemod/README.md
+++ b/tracemod/README.md
@@ -2,19 +2,37 @@
 
 # tracemod
 
-Using tracemod takes care of exporting spans to otel endpoint and flushing buffers before the application exits.
+tracemod exports spans to the otel endpoint and flushes buffers before the application exits. Once installed, any otel tracer in the process feeds into the same exporter.
 
 ```go
 package main
 
 import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/go-srvc/mods/httpmod"
+	"github.com/go-srvc/mods/sigmod"
 	"github.com/go-srvc/mods/tracemod"
 	"github.com/go-srvc/srvc"
+	"go.opentelemetry.io/otel"
 )
 
 func main() {
 	srvc.RunAndExit(
 		tracemod.New(),
+		sigmod.New(os.Interrupt),
+		httpmod.New(
+			httpmod.WithAddr(":8080"),
+			httpmod.WithHandler(http.HandlerFunc(hello)),
+		),
 	)
+}
+
+func hello(w http.ResponseWriter, r *http.Request) {
+	_, span := otel.Tracer("hello").Start(r.Context(), "greet")
+	defer span.End()
+	fmt.Fprint(w, "hello, world")
 }
 ```


### PR DESCRIPTION
Match the style of the practical example on https://go-srvc.com so each mod's README shows a complete \`main.go\` that drops the mod into a realistic service skeleton (sigmod for shutdown, httpmod for serving, plus the focal mod doing its thing). Replaces the prior mix of minimal stubs and \`Store\`-style helpers.

## Per-mod changes

- **httpmod** — \`sigmod\` + \`httpmod.WithAddr/WithHandler\` + small handler. Drops the prior \`WithServerFn\` + ADDR-env example since most readers want the inline-handler shape first.
- **logmod** — same skeleton plus \`logmod.New()\`, handler calls \`slog.InfoContext\` to demonstrate the bridge.
- **metermod** — same skeleton plus \`metermod.New()\` (Go runtime metrics).
- **sigmod** — drops the \`http.DefaultServeMux\` shorthand; shows \`syscall.SIGTERM\` alongside \`os.Interrupt\` and a real handler.
- **sqlmod** — full service: \`sqlmod.WithOtel(\"pgx\", DSN, ...)\` + \`httpmod\` + handler running \`SELECT version()\` via \`QueryRowContext\`. Drops the \`Store\` embed wrapper which obscured the mod itself.
- **sqlxmod** — same as sqlmod but with \`sqlx.GetContext\`.
- **tickermod** — adds \`logmod\` + \`sigmod\` so the example is a complete logging-aware background worker.
- **tracemod** — adds \`sigmod\` + \`httpmod\`, handler starts a span via \`otel.Tracer(...).Start\` to show the exporter actually carrying spans somewhere.

Also tightened a few one-liners (\`logmod\`, \`metermod\`, \`sqlmod\`, \`sqlxmod\`, \`tracemod\`) so they describe what the mod does in one sentence instead of two.

## Test plan
- [ ] README examples look right on github.com/go-srvc/mods/<mod>
- [ ] CI green