### PR TITLE
Make tag release idempotent and use BOT_TOKEN for update cron

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -116,8 +116,8 @@ jobs:
         run: |
           tag=$(git tag --points-at HEAD --list '${{ matrix.mod }}/v*' | head -1)
           [ -z "$tag" ] && exit 0
-          git push origin "$tag"
-          gh release create "$tag" --title "$tag" --generate-notes
+          git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1 || git push origin "$tag"
+          gh release view "$tag" >/dev/null 2>&1 || gh release create "$tag" --title "$tag" --generate-notes
 
   ci:
     needs:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
 
       - id: go
         run: echo "version=$(curl -fsSL 'https://go.dev/dl/?mode=json' | jq -r '[.[] | select(.stable)] | .[0].version | sub("^go"; "")')" >> "$GITHUB_OUTPUT"
@@ -27,7 +29,7 @@ jobs:
 
       - name: Open PR if changes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           if git diff --quiet; then
             echo "no changes"


### PR DESCRIPTION
Two fixes after the v1.2.0 main run:

1. **Tag release step is now retry-safe.** `git push origin $tag` is skipped if the ref already exists on the remote, and `gh release create` is skipped if a release for $tag already exists. A transient 502 from `gh release create` (which is what tripped the metermod entry in run 26228364252) can now be recovered by re-running the failed matrix entry.
2. **Update-deps cron uses `secrets.BOT_TOKEN` instead of the default `GITHUB_TOKEN`.** A PR opened by `GITHUB_TOKEN` won't trigger workflows, so CI never ran on the cron's output. Using a PAT in both `actions/checkout` and `gh` CLI fixes that. Requires the `BOT_TOKEN` secret to be set (classic PAT with `repo`+`workflow`, or fine-grained with Contents/PR/Workflows write).