### PR TITLE
Drop GH Releases from tag workflow

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -110,14 +110,11 @@ jobs:
       - name: Tag
         run: make tag/${{ matrix.mod }}
 
-      - name: Push tag and create release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push tag
         run: |
           tag=$(git tag --points-at HEAD --list '${{ matrix.mod }}/v*' | head -1)
           [ -z "$tag" ] && exit 0
           git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1 || git push origin "$tag"
-          gh release view "$tag" >/dev/null 2>&1 || gh release create "$tag" --title "$tag" --generate-notes
 
   ci:
     needs:


### PR DESCRIPTION
The Go module proxy reads tags directly, GH Releases serve no Go-tooling purpose and clutter the Releases tab once you have multiple mods. Keep the tag push, drop the `gh release create`.