### PR TITLE
Auto-merge update-deps PR when CI is green

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -43,3 +43,4 @@ jobs:
           git push -f origin update-deps
           gh pr view update-deps --json state -q .state 2>/dev/null | grep -q OPEN || \
             gh pr create --title "Update Go, tools, and deps" --body "Weekly automated bump." --head update-deps --base main
+          gh pr merge update-deps --auto --merge


### PR DESCRIPTION
Enables `gh pr merge --auto` on the weekly bump PR so it merges itself once the required `ci` check passes. Requires branch protection on main to require the `ci` check, else GitHub merges immediately.