### PR TITLE
Update only direct deps and tools, not transitives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ GO_VERSION    ?= $(shell go env GOVERSION | sed 's/^go//')
 
 ${MODS_UPDATE}:
 	cd ./${@F} && go mod edit -go=${GO_VERSION}
-	cd ./${@F} && go get -u -t ./...
-	cd ./${@F} && go get -u tool
+	cd ./${@F} && pkgs=$$(go mod edit -json | jq -r '[(.Tool[]?.Path), (.Require[]? | select(.Indirect | not) | .Path)] | map(. + "@latest") | .[]'); \
+	  [ -z "$$pkgs" ] || go get $$pkgs
 	cd ./${@F} && go mod tidy
 
 .PHONY: api-check


### PR DESCRIPTION
Replace `go get -u -t ./...` + `go get -u tool` with a single `go get` that targets only the packages listed in the `tool ()` block and the non-indirect entries in `require ()`. `go mod tidy` then settles transitives at the minimum versions selected by MVS, instead of bumping them past what direct deps actually need. Fixes the goheader v1.0.0 / golangci-lint v2.12.2 incompat that has blocked PR #60.