### PR TITLE
fix: copy-paste bugs across modules

### DIFF
--- a/logmod/provider.go
+++ b/logmod/provider.go
@@ -131,17 +131,17 @@ func WithStdout(opt ...stdoutlog.Option) Opt {
 	}
 }
 
-// WithEnv uses OTEL_EXPORTER_OTLP_TRACES_PROTO and OTEL_EXPORTER_OTLP_PROTO environment variable to set exporter.
+// WithEnv uses OTEL_EXPORTER_OTLP_TRACES_PROTOCOL and OTEL_EXPORTER_OTLP_PROTOCOL environment variable to set exporter.
 // Accepted values are:
-//   - http
+//   - http/protobuf
 //   - grpc
 //   - stdout
 //
 // If no value is provided, stdout is used.
 func WithEnv() Opt {
 	return func(p *Provider) error {
-		switch strings.ToLower(cmp.Or(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTO"), os.Getenv("OTEL_EXPORTER_OTLP_PROTO"))) {
-		case "http":
+		switch strings.ToLower(cmp.Or(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"), os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"))) {
+		case "http/protobuf", "http/json":
 			return WithHTTP()(p)
 		case "grpc":
 			return WithGRPC()(p)

--- a/logmod/provider.go
+++ b/logmod/provider.go
@@ -74,14 +74,14 @@ func (p *Provider) ID() string { return ID }
 
 type Opt func(*Provider) error
 
-// WithProvider sets the underlying trace provider for module.
+// WithProvider sets the underlying log provider for module.
 func WithProvider(exp *log.LoggerProvider) Opt {
 	return WithProviderFn(func() (*log.LoggerProvider, error) {
 		return exp, nil
 	})
 }
 
-// WithProviderFn sets the underlying trace provider for module using given function.
+// WithProviderFn sets the underlying log provider for module using given function.
 func WithProviderFn(fn func() (*log.LoggerProvider, error)) Opt {
 	return func(p *Provider) error {
 		prov, err := fn()

--- a/logmod/provider.go
+++ b/logmod/provider.go
@@ -141,7 +141,7 @@ func WithStdout(opt ...stdoutlog.Option) Opt {
 func WithEnv() Opt {
 	return func(p *Provider) error {
 		switch strings.ToLower(cmp.Or(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"), os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"))) {
-		case "http/protobuf", "http/json":
+		case "http/protobuf":
 			return WithHTTP()(p)
 		case "grpc":
 			return WithGRPC()(p)

--- a/logmod/provider.go
+++ b/logmod/provider.go
@@ -66,8 +66,8 @@ func (p *Provider) Run() error {
 func (p *Provider) Stop() error {
 	close(p.done)
 	flushErr := p.provider.ForceFlush(context.Background())
-	shutdowErr := p.provider.Shutdown(context.Background())
-	return errors.Join(flushErr, shutdowErr)
+	shutdownErr := p.provider.Shutdown(context.Background())
+	return errors.Join(flushErr, shutdownErr)
 }
 
 func (p *Provider) ID() string { return ID }

--- a/metermod/provider.go
+++ b/metermod/provider.go
@@ -70,8 +70,8 @@ func (p *Provider) Stop() error {
 	if flushErr != nil {
 		flushErr = fmt.Errorf("%w: %w", ErrFlushFailed, flushErr)
 	}
-	shutdowErr := p.provider.Shutdown(context.Background())
-	return errors.Join(flushErr, shutdowErr)
+	shutdownErr := p.provider.Shutdown(context.Background())
+	return errors.Join(flushErr, shutdownErr)
 }
 
 func (p *Provider) ID() string { return ID }

--- a/metermod/provider.go
+++ b/metermod/provider.go
@@ -126,7 +126,7 @@ func WithGRPC() Opt {
 // WithStdout creates meter provider with stdout exporter.
 func WithStdout(opt ...stdoutmetric.Option) Opt {
 	return func(p *Provider) error {
-		exp, err := stdoutmetric.New()
+		exp, err := stdoutmetric.New(opt...)
 		if err != nil {
 			return fmt.Errorf("failed to create stdout exporter: %w", err)
 		}

--- a/metermod/provider.go
+++ b/metermod/provider.go
@@ -135,17 +135,17 @@ func WithStdout(opt ...stdoutmetric.Option) Opt {
 	}
 }
 
-// WithEnv uses OTEL_EXPORTER_OTLP_TRACES_PROTO and OTEL_EXPORTER_OTLP_PROTO environment variable to set exporter.
+// WithEnv uses OTEL_EXPORTER_OTLP_TRACES_PROTOCOL and OTEL_EXPORTER_OTLP_PROTOCOL environment variable to set exporter.
 // Accepted values are:
-//   - http
+//   - http/protobuf
 //   - grpc
 //   - stdout
 //
 // If no value is provided, stdout is used.
 func WithEnv() Opt {
 	return func(p *Provider) error {
-		switch strings.ToLower(cmp.Or(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTO"), os.Getenv("OTEL_EXPORTER_OTLP_PROTO"))) {
-		case "http":
+		switch strings.ToLower(cmp.Or(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"), os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"))) {
+		case "http/protobuf", "http/json":
 			return WithHTTP()(p)
 		case "grpc":
 			return WithGRPC()(p)

--- a/metermod/provider.go
+++ b/metermod/provider.go
@@ -145,7 +145,7 @@ func WithStdout(opt ...stdoutmetric.Option) Opt {
 func WithEnv() Opt {
 	return func(p *Provider) error {
 		switch strings.ToLower(cmp.Or(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"), os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"))) {
-		case "http/protobuf", "http/json":
+		case "http/protobuf":
 			return WithHTTP()(p)
 		case "grpc":
 			return WithGRPC()(p)

--- a/sqlxmod/db.go
+++ b/sqlxmod/db.go
@@ -54,8 +54,7 @@ func (d *DB) Run() error {
 
 func (d *DB) Stop() error {
 	defer close(d.done)
-	d.dbx.Close()
-	return nil
+	return d.dbx.Close()
 }
 
 func (d *DB) ID() string { return ID }

--- a/tracemod/provider.go
+++ b/tracemod/provider.go
@@ -77,8 +77,8 @@ func (p *Provider) Stop() error {
 	if flushErr != nil {
 		flushErr = fmt.Errorf("%w: %w", ErrFlushFailed, flushErr)
 	}
-	shutdowErr := p.provider.Shutdown(context.Background())
-	return errors.Join(flushErr, shutdowErr)
+	shutdownErr := p.provider.Shutdown(context.Background())
+	return errors.Join(flushErr, shutdownErr)
 }
 
 func (p *Provider) ID() string { return ID }

--- a/tracemod/provider.go
+++ b/tracemod/provider.go
@@ -152,7 +152,7 @@ func WithStdout(opt ...stdouttrace.Option) Opt {
 func WithEnv() Opt {
 	return func(p *Provider) error {
 		switch strings.ToLower(cmp.Or(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"), os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"))) {
-		case "http/protobuf", "http/json":
+		case "http/protobuf":
 			return WithHTTP()(p)
 		case "grpc":
 			return WithGRPC()(p)

--- a/tracemod/provider.go
+++ b/tracemod/provider.go
@@ -104,7 +104,7 @@ func WithProviderFn(fn func() (*trace.TracerProvider, error)) Opt {
 	}
 }
 
-// WithHTTP creates meter provider with periodic reader using http exporter from OTEL_* env configs.
+// WithHTTP creates trace provider with batch span processor using http exporter from OTEL_* env configs.
 // Env variables: https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
 func WithHTTP() Opt {
 	return func(p *Provider) error {
@@ -117,7 +117,7 @@ func WithHTTP() Opt {
 	}
 }
 
-// WithGRPC creates meter provider with periodic reader using grpc exporter from OTEL_* env configs.
+// WithGRPC creates trace provider with batch span processor using grpc exporter from OTEL_* env configs.
 // Env variables: https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
 func WithGRPC() Opt {
 	return func(p *Provider) error {

--- a/tracemod/provider.go
+++ b/tracemod/provider.go
@@ -133,7 +133,7 @@ func WithGRPC() Opt {
 // WithStdout creates trace provider with stdout exporter.
 func WithStdout(opt ...stdouttrace.Option) Opt {
 	return func(p *Provider) error {
-		exp, err := stdouttrace.New()
+		exp, err := stdouttrace.New(opt...)
 		if err != nil {
 			return fmt.Errorf("failed to create stdout exporter: %w", err)
 		}

--- a/tracemod/provider.go
+++ b/tracemod/provider.go
@@ -142,17 +142,17 @@ func WithStdout(opt ...stdouttrace.Option) Opt {
 	}
 }
 
-// WithEnv uses OTEL_EXPORTER_OTLP_TRACES_PROTO and OTEL_EXPORTER_OTLP_PROTO environment variable to set exporter.
+// WithEnv uses OTEL_EXPORTER_OTLP_TRACES_PROTOCOL and OTEL_EXPORTER_OTLP_PROTOCOL environment variable to set exporter.
 // Accepted values are:
-//   - http
+//   - http/protobuf
 //   - grpc
 //   - stdout
 //
 // If no value is provided, stdout is used.
 func WithEnv() Opt {
 	return func(p *Provider) error {
-		switch strings.ToLower(cmp.Or(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTO"), os.Getenv("OTEL_EXPORTER_OTLP_PROTO"))) {
-		case "http":
+		switch strings.ToLower(cmp.Or(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"), os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"))) {
+		case "http/protobuf", "http/json":
 			return WithHTTP()(p)
 		case "grpc":
 			return WithGRPC()(p)


### PR DESCRIPTION
Fix copy-paste bugs across modules:

- WithEnv: use correct OTEL env var names (_PROTOCOL not _PROTO) and match spec value (http/protobuf)
- WithStdout: pass options to exporter instead of ignoring them
- sqlxmod: return error from Close instead of discarding it
- Fix wrong godoc references (logmod said "trace", tracemod said "meter")
- Fix shutdowErr typo