### PR TITLE
sigmod: unify defaults, add cross-compile check for windows and darwin

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -67,6 +67,9 @@ jobs:
       - name: API check
         run: make api-check/${{ matrix.mod }}
 
+      - name: Cross-compile
+        run: make cross-check/${{ matrix.mod }}
+
       - name: Test
         run: make test/${{ matrix.mod }}
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ MODS_UPDATE   := ${MOD_NAMES:%=update-deps/%}
 MODS_DOWNLOAD := ${MOD_NAMES:%=download/%}
 MODS_APICHECK := ${MOD_NAMES:%=api-check/%}
 MODS_TAG      := ${MOD_NAMES:%=tag/%}
+MODS_CROSS    := ${MOD_NAMES:%=cross-check/%}
 
 REMOTE        ?= origin
 mod_last_tag   = $(shell git ls-remote --tags --refs ${REMOTE} '$(1)/v*' | sed 's|.*refs/tags/||' | sort -V | tail -1)
@@ -85,6 +86,14 @@ ${MODS_TAG}:
 	  test -n "$$v" || { echo "${MOD}: gorelease did not suggest a version" >&2; exit 1; }; \
 	fi; \
 	git tag "${MOD}/$$v" && echo "tagged ${MOD}/$$v"
+
+.PHONY: cross-check
+cross-check: ${MODS_CROSS} ## Cross-compile each mod for windows and darwin
+
+.PHONY: ${MODS_CROSS}
+${MODS_CROSS}:
+	cd ./${@F} && GOOS=windows go build ./...
+	cd ./${@F} && GOOS=darwin  go build ./...
 
 .PHONY: clean
 clean: ## Clean files

--- a/sigmod/defaults.go
+++ b/sigmod/defaults.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 package sigmod
 
 import (

--- a/sigmod/defaults_win.go
+++ b/sigmod/defaults_win.go
@@ -1,7 +1,0 @@
-//go:build windows
-
-package sigmod
-
-import "os"
-
-var defaultSignals = []os.Signal{os.Kill}


### PR DESCRIPTION
## sigmod
`os.Interrupt, syscall.SIGTERM` is the right default on both Unix and Windows since Go 1.20 (the runtime delivers SIGTERM for CTRL_CLOSE/LOGOFF/SHUTDOWN). The old Windows-only `os.Kill` default was never deliverable, so a default-constructed Listener on Windows blocked forever. Collapse the two files into one.

## CI
New `make cross-check/<mod>` builds each mod with `GOOS=windows` and `GOOS=darwin` so platform-specific compile breaks are caught. Wired into the per-mod test job in the matrix.