### PR TITLE
Trigger website Deploy on tag push

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -104,6 +104,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.BOT_TOKEN }}
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/trigger-website.yml
+++ b/.github/workflows/trigger-website.yml
@@ -1,0 +1,16 @@
+name: Trigger website
+
+on:
+  push:
+    tags: ['*mod/v*']
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: gh workflow run deploy.yml -R go-srvc/website


### PR DESCRIPTION
Adds a one-job workflow that fires `gh workflow run deploy.yml -R go-srvc/website` whenever a `<mod>/v*` tag is pushed.

Also switches the `tag` job's checkout to use `BOT_TOKEN` instead of the default `GITHUB_TOKEN`. Tags pushed by `GITHUB_TOKEN` don't trigger downstream workflows, so the new trigger would never fire without this.

Note: `BOT_TOKEN` needs `Actions: Read and write` on `go-srvc/website` to dispatch the deploy workflow.