### PR TITLE
Dispatch website Deploy once after tag job succeeds

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -119,14 +119,8 @@ jobs:
           [ -z "$tag" ] && exit 0
           git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1 || git push origin "$tag"
 
-  website:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.discover.outputs.changed != '[]' }}
-    needs:
-      - discover
-      - tag
-    runs-on: ubuntu-latest
-    steps:
-      - env:
+      - name: Trigger website Deploy
+        env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: gh workflow run deploy.yml -R go-srvc/website
 
@@ -135,13 +129,11 @@ jobs:
       - discover
       - test
       - tag
-      - website
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Verify
         run: |
           [ "${{ needs.discover.result }}" = "success" ] || exit 1
-          case "${{ needs.test.result }}"    in success|skipped) ;; *) exit 1 ;; esac
-          case "${{ needs.tag.result }}"     in success|skipped) ;; *) exit 1 ;; esac
-          case "${{ needs.website.result }}" in success|skipped) ;; *) exit 1 ;; esac
+          case "${{ needs.test.result }}" in success|skipped) ;; *) exit 1 ;; esac
+          case "${{ needs.tag.result }}"  in success|skipped) ;; *) exit 1 ;; esac

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -119,16 +119,29 @@ jobs:
           [ -z "$tag" ] && exit 0
           git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1 || git push origin "$tag"
 
+  website:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.discover.outputs.changed != '[]' }}
+    needs:
+      - discover
+      - tag
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: gh workflow run deploy.yml -R go-srvc/website
+
   ci:
     needs:
       - discover
       - test
       - tag
+      - website
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Verify
         run: |
           [ "${{ needs.discover.result }}" = "success" ] || exit 1
-          case "${{ needs.test.result }}" in success|skipped) ;; *) exit 1 ;; esac
-          case "${{ needs.tag.result }}"  in success|skipped) ;; *) exit 1 ;; esac
+          case "${{ needs.test.result }}"    in success|skipped) ;; *) exit 1 ;; esac
+          case "${{ needs.tag.result }}"     in success|skipped) ;; *) exit 1 ;; esac
+          case "${{ needs.website.result }}" in success|skipped) ;; *) exit 1 ;; esac


### PR DESCRIPTION
Adds a single `website` job in `go.yaml` that runs after the `tag` matrix completes on a successful main push with changes. Fires `gh workflow run deploy.yml -R go-srvc/website` once per CI run, regardless of how many mods got tagged. Aggregator `ci` job updated to wait for it.

Note: `BOT_TOKEN` needs `Actions: Read and write` on `go-srvc/website` for the dispatch to be authorized.