### PR TITLE
metermod,logmod: fix WithEnv env var names

### DIFF
--- a/logmod/provider.go
+++ b/logmod/provider.go
@@ -131,7 +131,7 @@ func WithStdout(opt ...stdoutlog.Option) Opt {
 	}
 }
 
-// WithEnv uses OTEL_EXPORTER_OTLP_TRACES_PROTOCOL and OTEL_EXPORTER_OTLP_PROTOCOL environment variable to set exporter.
+// WithEnv uses OTEL_EXPORTER_OTLP_LOGS_PROTOCOL and OTEL_EXPORTER_OTLP_PROTOCOL environment variable to set exporter.
 // Accepted values are:
 //   - http/protobuf
 //   - grpc
@@ -140,7 +140,7 @@ func WithStdout(opt ...stdoutlog.Option) Opt {
 // If no value is provided, stdout is used.
 func WithEnv() Opt {
 	return func(p *Provider) error {
-		switch strings.ToLower(cmp.Or(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"), os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"))) {
+		switch strings.ToLower(cmp.Or(os.Getenv("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"), os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"))) {
 		case "http/protobuf":
 			return WithHTTP()(p)
 		case "grpc":

--- a/metermod/provider.go
+++ b/metermod/provider.go
@@ -135,7 +135,7 @@ func WithStdout(opt ...stdoutmetric.Option) Opt {
 	}
 }
 
-// WithEnv uses OTEL_EXPORTER_OTLP_TRACES_PROTOCOL and OTEL_EXPORTER_OTLP_PROTOCOL environment variable to set exporter.
+// WithEnv uses OTEL_EXPORTER_OTLP_METRICS_PROTOCOL and OTEL_EXPORTER_OTLP_PROTOCOL environment variable to set exporter.
 // Accepted values are:
 //   - http/protobuf
 //   - grpc
@@ -144,7 +144,7 @@ func WithStdout(opt ...stdoutmetric.Option) Opt {
 // If no value is provided, stdout is used.
 func WithEnv() Opt {
 	return func(p *Provider) error {
-		switch strings.ToLower(cmp.Or(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"), os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"))) {
+		switch strings.ToLower(cmp.Or(os.Getenv("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"), os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"))) {
 		case "http/protobuf":
 			return WithHTTP()(p)
 		case "grpc":


### PR DESCRIPTION
Fix copy-paste bug. metermod and logmod both read OTEL_EXPORTER_OTLP_TRACES_PROTOCOL. Wrong signal. Now metermod reads OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, logmod reads OTEL_EXPORTER_OTLP_LOGS_PROTOCOL.